### PR TITLE
Fallbacks when parse failed

### DIFF
--- a/src/compiler.c
+++ b/src/compiler.c
@@ -53,7 +53,10 @@ bool Compile(Scope *scope, StreamInterface *si)
   } else {
     success = false;
   }
-  ParseFreeAllNode(parser);
+  if (success) {
+    /* FIXME skipping FreeNode causes memory leak */
+    ParseFreeAllNode(parser);
+  }
   ParserStateFree(p);
   ParseFree(parser, mmrbc_free);
   Tokenizer_free(tokenizer);

--- a/src/tokenizer.c
+++ b/src/tokenizer.c
@@ -529,6 +529,7 @@ int Tokenizer_advance(Tokenizer* const self, bool recursive)
     } else {
       ERRORP("Failed to tokenize!");
       Token_free(lazyToken);
+      self->pos += 1; /* skip one */
       return 1;
     }
   }


### PR DESCRIPTION
- [SOLVED] tokenizer ignores a token if it is not valid

- [TENTATIVE!] avoid SEVG by leaving memory leak
  - https://github.com/hasumikin/mmruby/compare/fallback_parse_failure?expand=1#diff-6c198db2860ea5d7abc9160b828f6c8dR57
